### PR TITLE
Functional requirements: Added mihomo's metacubexd UI panel

### DIFF
--- a/main/commands/update.go
+++ b/main/commands/update.go
@@ -608,7 +608,7 @@ func updateMetacubexd() error {
             return e.New("read tar file failed, ", err).WithPrefix(tagUpdate)
         }
 
-        target := filepath.Join(builds.Config.XrayHelper.DataDir, header.Name)
+        target := filepath.Join(builds.Config.XrayHelper.DataDir,"Yacd-meta-gh-pages", header.Name)
 
         switch header.Typeflag {
         case tar.TypeDir:

--- a/main/commands/update.go
+++ b/main/commands/update.go
@@ -6,7 +6,6 @@ import (
 	e "XrayHelper/main/errors"
 	"XrayHelper/main/log"
 	"XrayHelper/main/serial"
-	"compress/gzip"
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"

--- a/main/commands/update.go
+++ b/main/commands/update.go
@@ -544,6 +544,7 @@ func updateYacdMeta() error {
 	}
 	for _, file := range zipReader.File {
 		t := filepath.Join(builds.Config.XrayHelper.DataDir, file.Name)
+		t = strings.Replace(t, "/./", "/mihomoUI/", 1)
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(t, 0644); err != nil {
 				return e.New("create dir "+t+" failed, ", err).WithPrefix(tagUpdate)
@@ -609,6 +610,7 @@ func updateMetacubexd() error {
         }
 
         target := filepath.Join(builds.Config.XrayHelper.DataDir, header.Name)
+		target = strings.Replace(target, "/./", "/mihomoUI/", 1)
 
         switch header.Typeflag {
         case tar.TypeDir:

--- a/main/commands/update.go
+++ b/main/commands/update.go
@@ -544,7 +544,6 @@ func updateYacdMeta() error {
 	}
 	for _, file := range zipReader.File {
 		t := filepath.Join(builds.Config.XrayHelper.DataDir, file.Name)
-		t = strings.Replace(t, "/./", "/mihomoUI/", 1)
 		if file.FileInfo().IsDir() {
 			if err := os.MkdirAll(t, 0644); err != nil {
 				return e.New("create dir "+t+" failed, ", err).WithPrefix(tagUpdate)
@@ -596,7 +595,7 @@ func updateMetacubexd() error {
 
     tarReader := tar.NewReader(gzr)
 
-    if err := os.RemoveAll(path.Join(builds.Config.XrayHelper.DataDir, "./")); err != nil {
+    if err := os.RemoveAll(path.Join(builds.Config.XrayHelper.DataDir, "Yacd-meta-gh-pages/")); err != nil {
         return e.New("remove old metacubex files failed, ", err).WithPrefix(tagUpdate)
     }
 
@@ -610,7 +609,6 @@ func updateMetacubexd() error {
         }
 
         target := filepath.Join(builds.Config.XrayHelper.DataDir, header.Name)
-		target = strings.Replace(target, "/./", "/mihomoUI/", 1)
 
         switch header.Typeflag {
         case tar.TypeDir:

--- a/main/commands/update.go
+++ b/main/commands/update.go
@@ -580,7 +580,7 @@ func updateMetacubexd() error {
 
     file, err := os.Open(metacubexdTgzPath)
     if err != nil {
-        return errors.Wrap(err, "open tgz file failed")
+        return e.New("open tgz file failed, ", err).WithPrefix(tagUpdate)
     }
     defer func() {
         _ = file.Close()
@@ -589,14 +589,14 @@ func updateMetacubexd() error {
 
     gzr, err := gzip.NewReader(file)
     if err != nil {
-        return errors.Wrap(err, "create gzip reader failed")
+        return e.New("create gzip reader failed, ", err).WithPrefix(tagUpdate)
     }
     defer gzr.Close()
 
     tarReader := tar.NewReader(gzr)
 
     if err := os.RemoveAll(path.Join(builds.Config.XrayHelper.DataDir, "./")); err != nil {
-        return errors.Wrap(err, "remove old metacubex files failed")
+        return e.New("remove old metacubex files failed, ", err).WithPrefix(tagUpdate)
     }
 
     for {
@@ -605,7 +605,7 @@ func updateMetacubexd() error {
             break
         }
         if err != nil {
-            return errors.Wrap(err, "read tar file failed")
+            return e.New("read tar file failed, ", err).WithPrefix(tagUpdate)
         }
 
         target := filepath.Join(builds.Config.XrayHelper.DataDir, header.Name)
@@ -613,20 +613,20 @@ func updateMetacubexd() error {
         switch header.Typeflag {
         case tar.TypeDir:
             if err := os.MkdirAll(target, 0755); err != nil {
-                return errors.Wrap(err, "create dir "+target+" failed")
+                return e.New("create dir "+target+" failed, ", err).WithPrefix(tagUpdate)
             }
         case tar.TypeReg:
             f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
             if err != nil {
-                return errors.Wrap(err, "open file "+target+" failed")
+                return e.New("open file "+target+" failed, ", err).WithPrefix(tagUpdate)
             }
             if _, err := io.Copy(f, tarReader); err != nil {
                 _ = f.Close()
-                return errors.Wrap(err, "copy file "+target+" failed")
+                return e.New("copy file "+target+" failed, ", err).WithPrefix(tagUpdate)
             }
             _ = f.Close()
         default:
-            return errors.New("unknown type: " + string(header.Typeflag))
+            return e.New("unknown type: " + string(header.Typeflag)).WithPrefix(tagUpdate)
         }
     }
 


### PR DESCRIPTION
Functional requirements: Add mihomo's metacubexd UI panel, the new panel looks cute~    

Tested for no bugs,[another site](https://github.com/Asterisk4Magisk/Xray4Magisk/pull/103/files)      

btw：
Due to the older version of the module
The mihomo configuration injection is already written in template.yaml
```yaml
external-ui: /data/adb/xray/data/Yacd-meta-gh-pages
```

In the case of a non-fresh installation, in order to avoid breaking updates, update metacubeexd continues to share the Yacd-meta-gh-pages directory of the update yacd-meta methoda方法的Yacd-meta-gh-pages目录